### PR TITLE
refactor: node scripts for experiments

### DIFF
--- a/billiards/README.md
+++ b/billiards/README.md
@@ -28,6 +28,11 @@ It correctly bundles Solid in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
 
+
+### `npm run test`
+
+Run the experiment in headless mode. Uses `tsx` to run the experiment with default parameters.
+
 ## Deployment
 
 Learn more about deploying your application with the [documentations](https://vitejs.dev/guide/static-deploy.html)

--- a/billiards/package-lock.json
+++ b/billiards/package-lock.json
@@ -13,6 +13,7 @@
         "vite-plugin-top-level-await": "^1.3.1"
       },
       "devDependencies": {
+        "tsx": "^4.7.2",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
         "vite-plugin-solid": "^2.7.0"
@@ -498,6 +499,22 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1380,6 +1397,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1531,6 +1560,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
@@ -1621,6 +1659,415 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.2.tgz",
+      "integrity": "sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
       }
     },
     "node_modules/typescript": {

--- a/billiards/package.json
+++ b/billiards/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+		"test": "tsx src/script.ts"
   },
   "dependencies": {
     "rose": "^0.4.10",
@@ -14,6 +15,7 @@
     "vite-plugin-top-level-await": "^1.3.1"
   },
   "devDependencies": {
+    "tsx": "^4.7.2",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vite-plugin-solid": "^2.7.0"

--- a/billiards/src/Table.tsx
+++ b/billiards/src/Table.tsx
@@ -1,217 +1,14 @@
-import {
-  Real,
-  Vec,
-  add,
-  and,
-  compile,
-  div,
-  fn,
-  lt,
-  mul,
-  select,
-  sub,
-  vjp,
-} from "rose";
 import { createEffect, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 import {
-  Vec2,
-  dot,
-  min,
-  norm,
-  normalize,
-  pow,
-  vadd2,
-  vmul,
-  vsub2,
-} from "./lib";
+  ballCount,
+  init,
+  optimize,
+  radius,
+  steps,
+  stepsCompiled,
+} from "./optimizer";
 
-// constants
-const maxSteps = 2048;
-const visInterval = 64;
-const outputInterval = 16;
-const steps = 1024;
-
-const layers = 4;
-const ballCount = Math.round(1 + ((1 + layers) * layers) / 2);
-const radius = 0.03;
-const elasticity = 0.8;
-
-// const alpha = 0.0;
-const learningRate = 0.01;
-
-const init_x: number[] = [];
-const init_v: number[] = [];
-const loss: number[] = [];
-
-const [dt, setdt] = createSignal(0.003);
-
-// all the balls
-// const alpha = -Math.PI / 70;
-const alpha = 0;
-
-// ball collision
-
-const collidePair = fn(
-  [Vec2, Vec2, Vec2, Vec2],
-  { x_inc_contrib: Vec2, imp: Vec2 },
-  (x1, x2, v1, v2) => {
-    const dist = vsub2(vadd2(x1, vmul(dt(), v1)), vadd2(x2, vmul(dt(), v2)));
-    const distNorm = norm(dist);
-    const relativeV = vsub2(v1, v2);
-    const dir = normalize(dist, 1e-6);
-    const projectedV = dot(dir, relativeV);
-    const cond = and(lt(distNorm, 2 * radius), lt(projectedV, 0));
-    const imp = select(
-      cond,
-      Vec2,
-      vmul(mul(-(1 + elasticity) * 0.5 * 1, projectedV), dir),
-      [0, 0]
-    );
-    const toi = div(sub(distNorm, 2 * radius), min(-1e-3, projectedV));
-    const x_inc_contrib = select(
-      cond,
-      Vec2,
-      vmul(min(sub(toi, dt()), 0), imp),
-      [0, 0]
-    );
-    return { x_inc_contrib, imp };
-  }
-);
-
-const Rack = Vec(ballCount, Vec2);
-
-const step = fn([Rack, Rack], { x: Rack, v: Rack }, (init_x, init_v) => {
-  // copy over the initial values
-  const x: Vec<Real>[] = [];
-  const v: Vec<Real>[] = [];
-  for (let i = 0; i < ballCount; i++) {
-    x.push(init_x[i]);
-    v.push(init_v[i]);
-  }
-  // collide all pairs of balls
-  const x_inc: (Vec<Real> | number[])[] = [];
-  const impulse: (Vec<Real> | number[])[] = [];
-  for (let i = 0; i < ballCount; i++) {
-    x_inc.push([0, 0]);
-    impulse.push([0, 0]);
-  }
-  for (let i = 0; i < ballCount; i++) {
-    for (let j = 0; j < ballCount; j++) {
-      if (i === j) continue;
-      const { x_inc_contrib, imp } = collidePair(x[i], x[j], v[i], v[j]);
-      x_inc[i] = vadd2(x_inc[i], x_inc_contrib);
-      impulse[i] = vadd2(impulse[i], imp);
-    }
-  }
-
-  // update ball positions
-  for (let i = 0; i < ballCount; i++) {
-    v[i] = vadd2(v[i], impulse[i]);
-    x[i] = vadd2(vadd2(x[i], x_inc[i]), vmul(dt(), v[i]));
-  }
-
-  return { x, v };
-});
-
-// main simulation step
-const allSteps = fn([Rack, Rack], Vec(steps, Rack), (init_x, init_v) => {
-  const xs = [];
-  let x = init_x;
-  let v = init_v;
-  for (let t = 0; t < steps; t++) {
-    const { x: newX, v: newV } = step(x, v);
-    x = newX;
-    v = newV;
-    xs.push(x);
-  }
-  return xs;
-});
-
-const init = (): {
-  initX: number[][];
-  initV: number[][];
-} => {
-  // initialize cue ball position and speed
-  const initX = [];
-  initX[0] = [0.1, 0.5];
-  const initV = [];
-  initV[0] = [0.3, 0.0];
-  // initialize other balls
-  let count = 0;
-  for (let i = 0; i < layers; i++) {
-    for (let j = 0; j < i + 1; j++) {
-      count += 1;
-      initX[count] = [
-        i * 2 * radius + 0.5,
-        j * 2 * radius + 0.5 - i * radius * 0.7,
-      ];
-      initV[count] = [0, 0];
-    }
-  }
-  return {
-    initV,
-    initX,
-  };
-};
-
-const computeLoss = fn([Vec2, Vec2], Real, (current, goal) =>
-  add(pow(sub(current[0], goal[0]), 2), pow(sub(current[1], goal[1]), 2))
-);
-
-const F = fn(
-  [{ x: Rack, v: Rack, goal: Vec2, targetBall: ballCount }],
-  Real,
-  ({ x, v, goal, targetBall }) => {
-    const xs = allSteps(x, v);
-    return computeLoss(xs[steps - 1][targetBall], goal);
-  }
-);
-
-const gradF = fn(
-  [{ x: Rack, v: Rack, goal: Vec2, targetBall: ballCount }],
-  { gradX: Vec2, gradV: Vec2, loss: Real },
-  ({ x, v, goal, targetBall }) => {
-    const f = vjp(F)({ x, v, goal, targetBall });
-    const g = f.grad(1);
-    return {
-      loss: f.ret,
-      gradX: g.x[0],
-      gradV: g.v[0],
-    };
-  }
-);
-const optimize = (goal: number[], targetBall: number) => {
-  let optX = [0.1, 0.5];
-  let optV = [0.3, 0.0];
-
-  for (let i = 0; i < 200; i++) {
-    // initialize the board
-    const { initX, initV } = init();
-    // plug in the optimized initial values
-    initX[0] = [...optX];
-    initV[0] = [...optV];
-    const { gradX, gradV, loss } = gradCompiled({
-      x: initX,
-      v: initV,
-      goal,
-      targetBall,
-    });
-    // update the optimized values by descenting the gradient
-    optX[0] = optX[0] - learningRate * gradX[0];
-    optX[1] = optX[1] - learningRate * gradX[1];
-    optV[0] = optV[0] - learningRate * gradV[0];
-    optV[1] = optV[1] - learningRate * gradV[1];
-    console.log(`iter=${i} loss: ${loss}`);
-    console.log(`iter=${i} grad X: ${gradX}`);
-    console.log(`iter=${i} grad V: ${gradV}`);
-  }
-  return { x: optX, v: optV };
-};
-
-const stepsAndLossCompiled = await compile(F);
-const stepsCompiled = await compile(allSteps);
-const gradCompiled = await compile(gradF);
 // const stepsCompiled = interp(allSteps);
 
 export default function Table() {
@@ -248,7 +45,6 @@ export default function Table() {
     }, 1);
   };
 
-  const [dragging, setDragging] = createSignal(false);
   const [goal, setGoal] = createStore([0.9, 0.75]);
   const [targetBall, setTargetBall] = createSignal(ballCount - 1);
   const getPosition = (
@@ -272,7 +68,6 @@ export default function Table() {
     const minY = radius;
     const maxY = h - radius;
 
-    setDragging(true);
     const onMouseMove = (e: MouseEvent) => {
       const { clientX, clientY } = e;
       const { x: newX, y: newY } = getPosition({ clientX, clientY }, svg!);
@@ -282,7 +77,6 @@ export default function Table() {
       setGoal(newGoal);
     };
     const onMouseUp = () => {
-      setDragging(false);
       document.removeEventListener("mouseup", onMouseUp);
       document.removeEventListener("mousemove", onMouseMove);
     };

--- a/billiards/src/optimizer.ts
+++ b/billiards/src/optimizer.ts
@@ -1,0 +1,203 @@
+import {
+  Real,
+  Vec,
+  add,
+  and,
+  compile,
+  div,
+  fn,
+  lt,
+  mul,
+  select,
+  sub,
+  vjp,
+} from "rose";
+import {
+  Vec2,
+  dot,
+  min,
+  norm,
+  normalize,
+  pow,
+  vadd2,
+  vmul,
+  vsub2,
+} from "./lib";
+
+// constants
+export const steps = 1024;
+export const layers = 4;
+export const ballCount = Math.round(1 + ((1 + layers) * layers) / 2);
+export const radius = 0.03;
+export const elasticity = 0.8;
+export const learningRate = 0.01;
+export const dt = 0.003;
+
+// ball collision
+
+const collidePair = fn(
+  [Vec2, Vec2, Vec2, Vec2],
+  { x_inc_contrib: Vec2, imp: Vec2 },
+  (x1, x2, v1, v2) => {
+    const dist = vsub2(vadd2(x1, vmul(dt, v1)), vadd2(x2, vmul(dt, v2)));
+    const distNorm = norm(dist);
+    const relativeV = vsub2(v1, v2);
+    const dir = normalize(dist, 1e-6);
+    const projectedV = dot(dir, relativeV);
+    const cond = and(lt(distNorm, 2 * radius), lt(projectedV, 0));
+    const imp = select(
+      cond,
+      Vec2,
+      vmul(mul(-(1 + elasticity) * 0.5 * 1, projectedV), dir),
+      [0, 0]
+    );
+    const toi = div(sub(distNorm, 2 * radius), min(-1e-3, projectedV));
+    const x_inc_contrib = select(
+      cond,
+      Vec2,
+      vmul(min(sub(toi, dt), 0), imp),
+      [0, 0]
+    );
+    return { x_inc_contrib, imp };
+  }
+);
+
+const Rack = Vec(ballCount, Vec2);
+
+const step = fn([Rack, Rack], { x: Rack, v: Rack }, (init_x, init_v) => {
+  // copy over the initial values
+  const x: Vec<Real>[] = [];
+  const v: Vec<Real>[] = [];
+  for (let i = 0; i < ballCount; i++) {
+    x.push(init_x[i]);
+    v.push(init_v[i]);
+  }
+  // collide all pairs of balls
+  const x_inc: (Vec<Real> | number[])[] = [];
+  const impulse: (Vec<Real> | number[])[] = [];
+  for (let i = 0; i < ballCount; i++) {
+    x_inc.push([0, 0]);
+    impulse.push([0, 0]);
+  }
+  for (let i = 0; i < ballCount; i++) {
+    for (let j = 0; j < ballCount; j++) {
+      if (i === j) continue;
+      const { x_inc_contrib, imp } = collidePair(x[i], x[j], v[i], v[j]);
+      x_inc[i] = vadd2(x_inc[i], x_inc_contrib);
+      impulse[i] = vadd2(impulse[i], imp);
+    }
+  }
+
+  // update ball positions
+  for (let i = 0; i < ballCount; i++) {
+    v[i] = vadd2(v[i], impulse[i]);
+    x[i] = vadd2(vadd2(x[i], x_inc[i]), vmul(dt, v[i]));
+  }
+
+  return { x, v };
+});
+
+// main simulation step
+const allSteps = fn([Rack, Rack], Vec(steps, Rack), (init_x, init_v) => {
+  const xs = [];
+  let x = init_x;
+  let v = init_v;
+  for (let t = 0; t < steps; t++) {
+    const { x: newX, v: newV } = step(x, v);
+    x = newX;
+    v = newV;
+    xs.push(x);
+  }
+  return xs;
+});
+
+export const init = (): {
+  initX: number[][];
+  initV: number[][];
+} => {
+  // initialize cue ball position and speed
+  const initX = [];
+  initX[0] = [0.1, 0.5];
+  const initV = [];
+  initV[0] = [0.3, 0.0];
+  // initialize other balls
+  let count = 0;
+  for (let i = 0; i < layers; i++) {
+    for (let j = 0; j < i + 1; j++) {
+      count += 1;
+      initX[count] = [
+        i * 2 * radius + 0.5,
+        j * 2 * radius + 0.5 - i * radius * 0.7,
+      ];
+      initV[count] = [0, 0];
+    }
+  }
+  return {
+    initV,
+    initX,
+  };
+};
+
+const computeLoss = fn([Vec2, Vec2], Real, (current, goal) =>
+  add(pow(sub(current[0], goal[0]), 2), pow(sub(current[1], goal[1]), 2))
+);
+
+const F = fn(
+  [{ x: Rack, v: Rack, goal: Vec2, targetBall: ballCount }],
+  Real,
+  ({ x, v, goal, targetBall }) => {
+    const xs = allSteps(x, v);
+    return computeLoss(xs[steps - 1][targetBall], goal);
+  }
+);
+
+const gradF = fn(
+  [{ x: Rack, v: Rack, goal: Vec2, targetBall: ballCount }],
+  { gradX: Vec2, gradV: Vec2, loss: Real },
+  ({ x, v, goal, targetBall }) => {
+    const f = vjp(F)({ x, v, goal, targetBall });
+    const g = f.grad(1);
+    return {
+      loss: f.ret,
+      gradX: g.x[0],
+      gradV: g.v[0],
+    };
+  }
+);
+
+export const stepsCompiled = await compile(allSteps);
+export const gradCompiled = await compile(gradF);
+
+export const optimize = (goal: number[], targetBall: number) => {
+  let optX = [0.1, 0.5];
+  let optV = [0.3, 0.0];
+  let loss = Infinity;
+
+  for (let i = 0; i < 200; i++) {
+    // initialize the board
+    const { initX, initV } = init();
+    // plug in the optimized initial values
+    initX[0] = [...optX];
+    initV[0] = [...optV];
+    const {
+      gradX,
+      gradV,
+      loss: newLoss,
+    } = gradCompiled({
+      x: initX,
+      v: initV,
+      goal,
+      targetBall,
+    });
+    // update the optimized values by descenting the gradient
+    optX[0] = optX[0] - learningRate * gradX[0];
+    optX[1] = optX[1] - learningRate * gradX[1];
+    optV[0] = optV[0] - learningRate * gradV[0];
+    optV[1] = optV[1] - learningRate * gradV[1];
+    console.log(`iter=${i} loss: ${newLoss}`);
+    console.log(`iter=${i} grad X: ${gradX}`);
+    console.log(`iter=${i} grad V: ${gradV}`);
+    loss = newLoss;
+  }
+  return { x: optX, v: optV, loss };
+};

--- a/billiards/src/script.ts
+++ b/billiards/src/script.ts
@@ -1,4 +1,5 @@
 import { ballCount, init, optimize, stepsCompiled } from "./optimizer";
+import * as process from "process";
 
 // set up scene
 const goal = [0.9, 0.75];
@@ -18,3 +19,4 @@ console.log(
   `final target ball position=${xs[(xs as any).length - 1][targetBall]}`
 );
 console.log(`goal=${goal}`);
+process.exit();

--- a/billiards/src/script.ts
+++ b/billiards/src/script.ts
@@ -1,0 +1,20 @@
+import { ballCount, init, optimize, stepsCompiled } from "./optimizer";
+
+// set up scene
+const goal = [0.9, 0.75];
+const targetBall = ballCount - 1;
+const { initV, initX } = init();
+
+// record timing
+const start = performance.now();
+const { x: optX, v: optV, loss } = optimize(goal, targetBall);
+const end = performance.now();
+console.log(`optimization took ${end - start}ms`);
+initX[0] = optX as any;
+initV[0] = optV as any;
+const xs = stepsCompiled(initX, initV);
+console.log(`final loss=${loss}`);
+console.log(
+  `final target ball position=${xs[(xs as any).length - 1][targetBall]}`
+);
+console.log(`goal=${goal}`);

--- a/mass-spring/README.md
+++ b/mass-spring/README.md
@@ -27,6 +27,10 @@ It correctly bundles Solid in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
 
+### `npm run test`
+
+Run the experiment in headless mode. Uses `tsx` to run the experiment with default parameters.
+
 ## Deployment
 
 Learn more about deploying your application with the [documentations](https://vitejs.dev/guide/static-deploy.html)

--- a/mass-spring/package-lock.json
+++ b/mass-spring/package-lock.json
@@ -13,6 +13,7 @@
         "vite-plugin-top-level-await": "^1.3.1"
       },
       "devDependencies": {
+        "tsx": "^4.7.2",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
         "vite-plugin-solid": "^2.7.0"
@@ -498,6 +499,22 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1380,6 +1397,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1531,6 +1560,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
@@ -1621,6 +1659,415 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.2.tgz",
+      "integrity": "sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
       }
     },
     "node_modules/typescript": {

--- a/mass-spring/package.json
+++ b/mass-spring/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsx src/script.ts"
   },
   "dependencies": {
     "rose": "^0.4.10",
@@ -14,6 +15,7 @@
     "vite-plugin-top-level-await": "^1.3.1"
   },
   "devDependencies": {
+    "tsx": "^4.7.2",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vite-plugin-solid": "^2.7.0"

--- a/mass-spring/src/Scene.tsx
+++ b/mass-spring/src/Scene.tsx
@@ -1,47 +1,16 @@
-import {
-  Real,
-  Vec,
-  add,
-  and,
-  compile,
-  div,
-  fn,
-  lt,
-  mul,
-  neg,
-  select,
-  sub,
-  vec,
-  vjp,
-} from "rose";
 import { createEffect, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
-import { Vec2, exp, norm, sin, tanh, vadd2, vmul, vsub2 } from "./lib";
+import {
+  goal,
+  ground_height,
+  head_id,
+  init,
+  init_weights_biases,
+  optimize,
+  steps,
+  stepsCompiled,
+} from "./optimizer";
 import { Robot, robots } from "./robots";
-// constants
-const iter = 100;
-
-const steps = Math.floor(2048 / 3) * 2;
-const elasticity = 0.0;
-const ground_height = 0.1;
-const gravity = -4.8;
-const friction = 2.5;
-const gradient_clip = 1;
-const spring_omega = 10;
-const damping = 15;
-const dt = 0.004;
-
-const head_id = 0;
-const goal = [0.9, 0.2];
-const robot = robots[1]();
-const n_objects: number = robot.objects.length;
-const n_springs: number = robot.springs.length;
-
-// NN constants
-const learning_rate = 25;
-const n_sin_waves = 10;
-const n_hidden = 32;
-const n_input_states = n_sin_waves + 4 * n_objects + 2;
 
 const rgbToHex = (r: number, g: number, b: number) =>
   "#" +
@@ -52,355 +21,18 @@ const rgbToHex = (r: number, g: number, b: number) =>
     })
     .join("");
 
-const Objects = Vec(n_objects, Vec2);
-
-const compute_center = fn([Objects], Vec2, (objects) => {
-  let sum: Vec<Real> | number[] = [0, 0];
-  for (let i = 0; i < n_objects; i++) {
-    sum = vadd2(sum, objects[i]);
-  }
-  return vmul(div(1, n_objects), sum);
-});
-
-const Hidden = Vec(n_hidden, Real);
-const Weights1 = Vec(n_hidden, Vec(n_input_states, Real));
-const Weights2 = Vec(n_springs, Vec(n_hidden, Real));
-const Act = Vec(n_springs, Real);
-const Bias1 = Hidden;
-const Bias2 = Act;
-
-const apply_spring_force = fn([Objects, Act], Objects, (x, act) => {
-  const v_inc: (Vec<Real> | number[])[] = [];
-  for (let i = 0; i < n_objects; i++) {
-    v_inc.push([0, 0]);
-  }
-  for (let i = 0; i < n_springs; i++) {
-    const spring = robot.springs[i];
-    const a = spring.object1;
-    const b = spring.object2;
-    const pos_a = x[a];
-    const pos_b = x[b];
-    const dist = vsub2(pos_a, pos_b);
-    const length = add(norm(dist), 1e-4);
-    const target_length = mul(
-      spring.length,
-      add(1, mul(act[i], spring.actuation))
-    );
-    const impulse = vmul(
-      div(mul(dt * spring.stiffness, sub(length, target_length)), length),
-      dist
-    );
-    v_inc[a] = vsub2(v_inc[a], impulse);
-    v_inc[b] = vadd2(v_inc[b], impulse);
-  }
-  return v_inc;
-});
-
-const advance_no_toi = fn(
-  [Objects, Objects, Objects],
-  { next_x: Objects, next_v: Objects },
-  (x, v, v_inc) => {
-    const next_x: Vec<Real>[] = [];
-    const next_v: Vec<Real>[] = [];
-    for (let i = 0; i < n_objects; i++) {
-      const s = exp(-dt * damping);
-      const old_v = vadd2(vadd2(vmul(s, v[i]), [0, dt * gravity]), v_inc[i]);
-      const old_x = x[i];
-      const depth = sub(old_x[1], ground_height);
-      // friction projection
-      const new_v = select(
-        and(lt(depth, 0), lt(old_v[1], 0)),
-        Vec2,
-        [0, 0],
-        old_v
-      );
-      // const new_v = old_v;
-      const new_x = vadd2(old_x, vmul(dt, new_v));
-      next_v.push(new_v);
-      next_x.push(new_x);
-    }
-    return { next_v, next_x };
-  }
-);
-
-const advance_toi = fn(
-  [Objects, Objects, Objects],
-  { next_x: Objects, next_v: Objects },
-  (x, v, v_inc) => {
-    const next_x: Vec<Real>[] = [];
-    const next_v: Vec<Real>[] = [];
-    for (let i = 0; i < n_objects; i++) {
-      const s = exp(-dt * damping);
-      const old_v = vadd2(vadd2(vmul(s, v[i]), [0, dt * gravity]), v_inc[i]);
-      const old_x = x[i];
-      const new_x = vadd2(old_x, vmul(dt, old_v));
-      const cond = and(lt(new_x[1], ground_height), lt(old_v[1], -1e-4));
-      const toi = select(
-        cond,
-        Real,
-        div(neg(sub(old_x[1], ground_height)), old_v[1]),
-        0
-      );
-      const new_v = select(cond, Vec2, [0, 0], old_v);
-      const new_new_x = vadd2(
-        vadd2(old_x, vmul(toi, old_v)),
-        vmul(sub(dt, toi), new_v)
-      );
-
-      next_v.push(new_v);
-      next_x.push(new_new_x);
-    }
-    return { next_v, next_x };
-  }
-);
-
-const nn1 = fn(
-  [Real, Objects, Objects, Bias1, Vec2, Weights1],
-  Hidden,
-  (t, x, v, bias1, center, weights1) =>
-    vec(n_hidden, Real, (i) => {
-      let actuation: Real = 0;
-      for (let j = 0; j < n_sin_waves; j++) {
-        actuation = add(
-          actuation,
-          mul(
-            weights1[i][j],
-            sin(add(mul(t, spring_omega * dt), (2 * Math.PI * j) / n_sin_waves))
-          )
-        );
-      }
-      for (let j = 0; j < n_objects; j++) {
-        const offset = vsub2(x[j], center);
-        actuation = add(
-          actuation,
-          mul(mul(weights1[i][n_sin_waves + 4 * j], offset[0]), 0.05)
-        );
-        actuation = add(
-          actuation,
-          mul(mul(weights1[i][n_sin_waves + 4 * j + 1], offset[1]), 0.05)
-        );
-        actuation = add(
-          actuation,
-          mul(mul(weights1[i][n_sin_waves + 4 * j + 2], v[j][0]), 0.05)
-        );
-        actuation = add(
-          actuation,
-          mul(mul(weights1[i][n_sin_waves + 4 * j + 3], v[j][1]), 0.05)
-        );
-      }
-      actuation = add(
-        actuation,
-        mul(weights1[i][n_objects * 4 + n_sin_waves], sub(goal[0], center[0]))
-      );
-      actuation = add(
-        actuation,
-        mul(
-          weights1[i][n_objects * 4 + n_sin_waves + 1],
-          sub(goal[1], center[1])
-        )
-      );
-      actuation = add(actuation, bias1[i]);
-      actuation = tanh(actuation);
-      return actuation;
-    })
-);
-
-const nn2 = fn([Weights2, Hidden, Bias2], Act, (weights2, hidden, bias2) => {
-  const act = [];
-  for (let i = 0; i < n_springs; i++) {
-    let actuation: Real = 0;
-    for (let j = 0; j < n_hidden; j++) {
-      actuation = add(actuation, mul(weights2[i][j], hidden[j]));
-    }
-    actuation = add(actuation, bias2[i]);
-    actuation = tanh(actuation);
-    act.push(actuation);
-  }
-  return act;
-});
-
-// implicitly, the timestep is 0, 1, 2...
-const step = fn(
-  [Real, Objects, Objects, Weights1, Weights2, Bias1, Bias2],
-  { x: Objects, v: Objects, act: Act },
-  (t, init_x, init_v, weights1, weights2, bias1, bias2) => {
-    // copy over the initial values
-    const x: Vec<Real>[] = [];
-    const v: Vec<Real>[] = [];
-    for (let i = 0; i < n_objects; i++) {
-      x.push(init_x[i]);
-      v.push(init_v[i]);
-    }
-    // compute center and spring forces
-    const center = compute_center(x);
-    // go through neural network to compute actuations
-    const hidden = nn1(t, x, v, bias1, center, weights1);
-    const act = nn2(weights2, hidden, bias2);
-    // return v_inc for the next timestep
-    const v_inc = apply_spring_force(x, act);
-    // const { next_x, next_v } = advance_no_toi(x, v, v_inc);
-    const { next_x, next_v } = advance_toi(x, v, v_inc);
-    return { x: next_x, v: next_v, act };
-  }
-);
-
-function randn(): number {
-  let u = 0,
-    v = 0;
-  while (u === 0) u = Math.random(); // Converting [0,1) to (0,1)
-  while (v === 0) v = Math.random();
-  const z = Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
-  return z;
-}
-
-const init_weights_biases = () => {
-  const weights1: number[][] = [];
-  const weights2: number[][] = [];
-  const bias1: number[] = [];
-  const bias2: number[] = [];
-  for (let i = 0; i < n_hidden; i++) {
-    weights1.push([]);
-    for (let j = 0; j < n_input_states; j++) {
-      weights1[i].push(
-        randn() * Math.sqrt(2 / (n_hidden + n_input_states)) * 2
-      );
-    }
-    bias1.push(0);
-  }
-  for (let i = 0; i < n_springs; i++) {
-    weights2.push([]);
-    for (let j = 0; j < n_hidden; j++) {
-      weights2[i].push(randn() * Math.sqrt(2 / (n_hidden + n_springs)) * 3);
-    }
-    bias2.push(0);
-  }
-  return { weights1, weights2, bias1, bias2 };
-};
-
-const compute_loss = fn([Objects], Real, (x) => {
-  return neg(x[head_id][0]);
-});
-
-const allSteps = fn(
-  [Objects, Objects, Weights1, Weights2, Bias1, Bias2],
-  {
-    xs: Vec(steps, Objects),
-    acts: Vec(steps, Act),
-    loss: Real,
-  },
-  (init_x, init_v, weights1, weights2, bias1, bias2) => {
-    const xs = [];
-    const acts = [];
-    let x = init_x;
-    let v = init_v;
-    // different from original: the timestamp starts at 0
-    for (let t = 0; t < steps; t++) {
-      const {
-        x: newX,
-        v: newV,
-        act,
-      } = step(t, x, v, weights1, weights2, bias1, bias2);
-      x = newX;
-      v = newV;
-      xs.push(x);
-      acts.push(act);
-    }
-    return { xs, acts, loss: compute_loss(x) };
-  }
-);
-
-const F = fn(
-  [
-    {
-      init_x: Objects,
-      init_v: Objects,
-      weights1: Weights1,
-      weights2: Weights2,
-      bias1: Bias1,
-      bias2: Bias2,
-    },
-  ],
-  Real,
-  ({ init_x, init_v, weights1, weights2, bias1, bias2 }) => {
-    const { loss } = allSteps(init_x, init_v, weights1, weights2, bias1, bias2);
-    return loss;
-  }
-);
-
-const gradF = fn(
-  [Objects, Objects, Weights1, Weights2, Bias1, Bias2],
-  {
-    bias1Grad: Bias1,
-    bias2Grad: Bias2,
-    weights1Grad: Weights1,
-    weights2Grad: Weights2,
-    loss: Real,
-  },
-  (init_x, init_v, weights1, weights2, bias1, bias2) => {
-    const f = vjp(F)({ init_x, init_v, weights1, weights2, bias1, bias2 });
-    const {
-      bias1: bias1Grad,
-      bias2: bias2Grad,
-      weights1: weights1Grad,
-      weights2: weights2Grad,
-    } = f.grad(1);
-    return { bias1Grad, bias2Grad, weights1Grad, weights2Grad, loss: f.ret };
-  }
-);
-
-const stepsCompiled = await compile(allSteps);
-const gradCompiled = await compile(gradF);
-
-const optimize = () => {
-  const { initV, initX } = init(robot);
-  let { weights1, weights2, bias1, bias2 } = init_weights_biases();
-
-  for (let i = 0; i < iter; i++) {
-    let total_norm_sqr = 0;
-    const { loss, bias1Grad, bias2Grad, weights1Grad, weights2Grad } =
-      gradCompiled(initX, initV, weights1, weights2, bias1, bias2);
-    console.log(`Iter=${i} Loss=${loss}`);
-    for (let i = 0; i < n_hidden; i++) {
-      for (let j = 0; j < n_input_states; j++) {
-        total_norm_sqr += weights1Grad[i][j] ** 2;
-      }
-      total_norm_sqr += bias1Grad[i] ** 2;
-    }
-    for (let i = 0; i < n_springs; i++) {
-      for (let j = 0; j < n_hidden; j++) {
-        total_norm_sqr += weights2Grad[i][j] ** 2;
-      }
-      total_norm_sqr += bias2Grad[i] ** 2;
-    }
-
-    const gradient_clip = 0.2;
-    const scale = gradient_clip / (total_norm_sqr ** 0.5 + 1e-6);
-    for (let i = 0; i < n_hidden; i++) {
-      for (let j = 0; j < n_input_states; j++) {
-        weights1[i][j] -= scale * weights1Grad[i][j];
-      }
-      bias1[i] -= scale * bias1Grad[i];
-    }
-    for (let i = 0; i < n_springs; i++) {
-      for (let j = 0; j < n_hidden; j++) {
-        weights2[i][j] -= scale * weights2Grad[i][j];
-      }
-      bias2[i] -= scale * bias2Grad[i];
-    }
-  }
-  return { weights1, weights2, bias1, bias2 };
-};
-
 const RobotViz = ({
   robot,
   x,
   act,
+  head_id,
   w,
   h,
 }: {
   robot: Robot;
   x: number[][];
   act: number[];
+  head_id: number;
   w: number;
   h: number;
 }) => {
@@ -441,22 +73,11 @@ const RobotViz = ({
     </>
   );
 };
-
-const init = (robot: Robot): { initX: number[][]; initV: number[][] } => {
-  const initX = [];
-  const initV = [];
-  for (let i = 0; i < n_objects; i++) {
-    const object = robot.objects[i];
-    initX.push([object.x, object.y]);
-    initV.push([0, 0]);
-  }
-  return { initX, initV };
-};
-
 export default () => {
   const [w, h] = [512, 512];
   const toX = (x: number) => x * w;
   const toY = (y: number) => (1 - y) * h;
+  const robot = robots[1]();
 
   // signals
   const [currentT, setCurrentT] = createSignal(0);
@@ -467,14 +88,16 @@ export default () => {
   const [x, setX] = createStore<number[][]>(initX);
   const [act, setAct] = createStore<number[]>([]);
   const { weights1, weights2, bias1, bias2 } = init_weights_biases();
-  const {
-    acts: initActs,
-    xs: initXs,
-    loss: l,
-  } = stepsCompiled(initX, initV, weights1, weights2, bias1, bias2);
+  const { acts: initActs, xs: initXs } = stepsCompiled(
+    initX,
+    initV,
+    weights1,
+    weights2,
+    bias1,
+    bias2
+  );
   const [xs, setXs] = createStore<number[][][]>(initXs as any);
   const [acts, setActs] = createStore<number[][]>(initActs as any);
-  const [loss, setLoss] = createSignal(l);
 
   createEffect(() => {
     setX([...(xs[currentT()] as any)]);
@@ -489,14 +112,16 @@ export default () => {
       const { weights1, weights2, bias1, bias2 } = optimize();
       const end = performance.now();
       console.log(`Optimization took ${end - start}ms`);
-      const {
-        acts,
-        xs,
-        loss: newLoss,
-      } = stepsCompiled(initX, initV, weights1, weights2, bias1, bias2);
+      const { acts, xs } = stepsCompiled(
+        initX,
+        initV,
+        weights1,
+        weights2,
+        bias1,
+        bias2
+      );
       setXs([...(xs as any)]);
       setActs([...(acts as any)]);
-      setLoss(newLoss);
       setOptimizing(false);
     }, 10);
   };
@@ -523,7 +148,7 @@ export default () => {
           stroke={"#000000"}
           stroke-width={3}
         ></line>
-        <RobotViz robot={robot} x={x} act={act} w={w} h={h} />
+        <RobotViz robot={robot} x={x} act={act} w={w} h={h} head_id={head_id} />
       </svg>
       <div>
         T:

--- a/mass-spring/src/optimizer.ts
+++ b/mass-spring/src/optimizer.ts
@@ -1,0 +1,390 @@
+import {
+  Real,
+  Vec,
+  add,
+  and,
+  compile,
+  div,
+  fn,
+  lt,
+  mul,
+  neg,
+  select,
+  sub,
+  vec,
+  vjp,
+} from "rose";
+import { Vec2, exp, norm, sin, tanh, vadd2, vmul, vsub2 } from "./lib";
+import { Robot, robots } from "./robots";
+// constants
+const iter = 100;
+
+export const steps = Math.floor(2048 / 3) * 2;
+export const ground_height = 0.1;
+const gravity = -4.8;
+const spring_omega = 10;
+const damping = 15;
+const dt = 0.004;
+
+export const head_id = 0;
+export const goal = [0.9, 0.2];
+const robot = robots[1]();
+const n_objects: number = robot.objects.length;
+const n_springs: number = robot.springs.length;
+
+// NN constants
+const n_sin_waves = 10;
+const n_hidden = 32;
+const n_input_states = n_sin_waves + 4 * n_objects + 2;
+
+const Objects = Vec(n_objects, Vec2);
+
+const compute_center = fn([Objects], Vec2, (objects) => {
+  let sum: Vec<Real> | number[] = [0, 0];
+  for (let i = 0; i < n_objects; i++) {
+    sum = vadd2(sum, objects[i]);
+  }
+  return vmul(div(1, n_objects), sum);
+});
+
+const Hidden = Vec(n_hidden, Real);
+const Weights1 = Vec(n_hidden, Vec(n_input_states, Real));
+const Weights2 = Vec(n_springs, Vec(n_hidden, Real));
+const Act = Vec(n_springs, Real);
+const Bias1 = Hidden;
+const Bias2 = Act;
+
+export const init = (
+  robot: Robot
+): { initX: number[][]; initV: number[][] } => {
+  const initX = [];
+  const initV = [];
+  for (let i = 0; i < n_objects; i++) {
+    const object = robot.objects[i];
+    initX.push([object.x, object.y]);
+    initV.push([0, 0]);
+  }
+  return { initX, initV };
+};
+
+const apply_spring_force = fn([Objects, Act], Objects, (x, act) => {
+  const v_inc: (Vec<Real> | number[])[] = [];
+  for (let i = 0; i < n_objects; i++) {
+    v_inc.push([0, 0]);
+  }
+  for (let i = 0; i < n_springs; i++) {
+    const spring = robot.springs[i];
+    const a = spring.object1;
+    const b = spring.object2;
+    const pos_a = x[a];
+    const pos_b = x[b];
+    const dist = vsub2(pos_a, pos_b);
+    const length = add(norm(dist), 1e-4);
+    const target_length = mul(
+      spring.length,
+      add(1, mul(act[i], spring.actuation))
+    );
+    const impulse = vmul(
+      div(mul(dt * spring.stiffness, sub(length, target_length)), length),
+      dist
+    );
+    v_inc[a] = vsub2(v_inc[a], impulse);
+    v_inc[b] = vadd2(v_inc[b], impulse);
+  }
+  return v_inc;
+});
+
+// const advance_no_toi = fn(
+//   [Objects, Objects, Objects],
+//   { next_x: Objects, next_v: Objects },
+//   (x, v, v_inc) => {
+//     const next_x: Vec<Real>[] = [];
+//     const next_v: Vec<Real>[] = [];
+//     for (let i = 0; i < n_objects; i++) {
+//       const s = exp(-dt * damping);
+//       const old_v = vadd2(vadd2(vmul(s, v[i]), [0, dt * gravity]), v_inc[i]);
+//       const old_x = x[i];
+//       const depth = sub(old_x[1], ground_height);
+//       // friction projection
+//       const new_v = select(
+//         and(lt(depth, 0), lt(old_v[1], 0)),
+//         Vec2,
+//         [0, 0],
+//         old_v
+//       );
+//       // const new_v = old_v;
+//       const new_x = vadd2(old_x, vmul(dt, new_v));
+//       next_v.push(new_v);
+//       next_x.push(new_x);
+//     }
+//     return { next_v, next_x };
+//   }
+// );
+
+const advance_toi = fn(
+  [Objects, Objects, Objects],
+  { next_x: Objects, next_v: Objects },
+  (x, v, v_inc) => {
+    const next_x: Vec<Real>[] = [];
+    const next_v: Vec<Real>[] = [];
+    for (let i = 0; i < n_objects; i++) {
+      const s = exp(-dt * damping);
+      const old_v = vadd2(vadd2(vmul(s, v[i]), [0, dt * gravity]), v_inc[i]);
+      const old_x = x[i];
+      const new_x = vadd2(old_x, vmul(dt, old_v));
+      const cond = and(lt(new_x[1], ground_height), lt(old_v[1], -1e-4));
+      const toi = select(
+        cond,
+        Real,
+        div(neg(sub(old_x[1], ground_height)), old_v[1]),
+        0
+      );
+      const new_v = select(cond, Vec2, [0, 0], old_v);
+      const new_new_x = vadd2(
+        vadd2(old_x, vmul(toi, old_v)),
+        vmul(sub(dt, toi), new_v)
+      );
+
+      next_v.push(new_v);
+      next_x.push(new_new_x);
+    }
+    return { next_v, next_x };
+  }
+);
+
+const nn1 = fn(
+  [Real, Objects, Objects, Bias1, Vec2, Weights1],
+  Hidden,
+  (t, x, v, bias1, center, weights1) =>
+    vec(n_hidden, Real, (i) => {
+      let actuation: Real = 0;
+      for (let j = 0; j < n_sin_waves; j++) {
+        actuation = add(
+          actuation,
+          mul(
+            weights1[i][j],
+            sin(add(mul(t, spring_omega * dt), (2 * Math.PI * j) / n_sin_waves))
+          )
+        );
+      }
+      for (let j = 0; j < n_objects; j++) {
+        const offset = vsub2(x[j], center);
+        actuation = add(
+          actuation,
+          mul(mul(weights1[i][n_sin_waves + 4 * j], offset[0]), 0.05)
+        );
+        actuation = add(
+          actuation,
+          mul(mul(weights1[i][n_sin_waves + 4 * j + 1], offset[1]), 0.05)
+        );
+        actuation = add(
+          actuation,
+          mul(mul(weights1[i][n_sin_waves + 4 * j + 2], v[j][0]), 0.05)
+        );
+        actuation = add(
+          actuation,
+          mul(mul(weights1[i][n_sin_waves + 4 * j + 3], v[j][1]), 0.05)
+        );
+      }
+      actuation = add(
+        actuation,
+        mul(weights1[i][n_objects * 4 + n_sin_waves], sub(goal[0], center[0]))
+      );
+      actuation = add(
+        actuation,
+        mul(
+          weights1[i][n_objects * 4 + n_sin_waves + 1],
+          sub(goal[1], center[1])
+        )
+      );
+      actuation = add(actuation, bias1[i]);
+      actuation = tanh(actuation);
+      return actuation;
+    })
+);
+
+const nn2 = fn([Weights2, Hidden, Bias2], Act, (weights2, hidden, bias2) => {
+  const act = [];
+  for (let i = 0; i < n_springs; i++) {
+    let actuation: Real = 0;
+    for (let j = 0; j < n_hidden; j++) {
+      actuation = add(actuation, mul(weights2[i][j], hidden[j]));
+    }
+    actuation = add(actuation, bias2[i]);
+    actuation = tanh(actuation);
+    act.push(actuation);
+  }
+  return act;
+});
+
+// implicitly, the timestep is 0, 1, 2...
+const step = fn(
+  [Real, Objects, Objects, Weights1, Weights2, Bias1, Bias2],
+  { x: Objects, v: Objects, act: Act },
+  (t, init_x, init_v, weights1, weights2, bias1, bias2) => {
+    // copy over the initial values
+    const x: Vec<Real>[] = [];
+    const v: Vec<Real>[] = [];
+    for (let i = 0; i < n_objects; i++) {
+      x.push(init_x[i]);
+      v.push(init_v[i]);
+    }
+    // compute center and spring forces
+    const center = compute_center(x);
+    // go through neural network to compute actuations
+    const hidden = nn1(t, x, v, bias1, center, weights1);
+    const act = nn2(weights2, hidden, bias2);
+    // return v_inc for the next timestep
+    const v_inc = apply_spring_force(x, act);
+    // const { next_x, next_v } = advance_no_toi(x, v, v_inc);
+    const { next_x, next_v } = advance_toi(x, v, v_inc);
+    return { x: next_x, v: next_v, act };
+  }
+);
+
+function randn(): number {
+  let u = 0,
+    v = 0;
+  while (u === 0) u = Math.random(); // Converting [0,1) to (0,1)
+  while (v === 0) v = Math.random();
+  const z = Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+  return z;
+}
+
+export const init_weights_biases = () => {
+  const weights1: number[][] = [];
+  const weights2: number[][] = [];
+  const bias1: number[] = [];
+  const bias2: number[] = [];
+  for (let i = 0; i < n_hidden; i++) {
+    weights1.push([]);
+    for (let j = 0; j < n_input_states; j++) {
+      weights1[i].push(
+        randn() * Math.sqrt(2 / (n_hidden + n_input_states)) * 2
+      );
+    }
+    bias1.push(0);
+  }
+  for (let i = 0; i < n_springs; i++) {
+    weights2.push([]);
+    for (let j = 0; j < n_hidden; j++) {
+      weights2[i].push(randn() * Math.sqrt(2 / (n_hidden + n_springs)) * 3);
+    }
+    bias2.push(0);
+  }
+  return { weights1, weights2, bias1, bias2 };
+};
+
+const compute_loss = fn([Objects], Real, (x) => {
+  return neg(x[head_id][0]);
+});
+
+const allSteps = fn(
+  [Objects, Objects, Weights1, Weights2, Bias1, Bias2],
+  {
+    xs: Vec(steps, Objects),
+    acts: Vec(steps, Act),
+    loss: Real,
+  },
+  (init_x, init_v, weights1, weights2, bias1, bias2) => {
+    const xs = [];
+    const acts = [];
+    let x = init_x;
+    let v = init_v;
+    // different from original: the timestamp starts at 0
+    for (let t = 0; t < steps; t++) {
+      const {
+        x: newX,
+        v: newV,
+        act,
+      } = step(t, x, v, weights1, weights2, bias1, bias2);
+      x = newX;
+      v = newV;
+      xs.push(x);
+      acts.push(act);
+    }
+    return { xs, acts, loss: compute_loss(x) };
+  }
+);
+
+const F = fn(
+  [
+    {
+      init_x: Objects,
+      init_v: Objects,
+      weights1: Weights1,
+      weights2: Weights2,
+      bias1: Bias1,
+      bias2: Bias2,
+    },
+  ],
+  Real,
+  ({ init_x, init_v, weights1, weights2, bias1, bias2 }) => {
+    const { loss } = allSteps(init_x, init_v, weights1, weights2, bias1, bias2);
+    return loss;
+  }
+);
+
+const gradF = fn(
+  [Objects, Objects, Weights1, Weights2, Bias1, Bias2],
+  {
+    bias1Grad: Bias1,
+    bias2Grad: Bias2,
+    weights1Grad: Weights1,
+    weights2Grad: Weights2,
+    loss: Real,
+  },
+  (init_x, init_v, weights1, weights2, bias1, bias2) => {
+    const f = vjp(F)({ init_x, init_v, weights1, weights2, bias1, bias2 });
+    const {
+      bias1: bias1Grad,
+      bias2: bias2Grad,
+      weights1: weights1Grad,
+      weights2: weights2Grad,
+    } = f.grad(1);
+    return { bias1Grad, bias2Grad, weights1Grad, weights2Grad, loss: f.ret };
+  }
+);
+
+export const stepsCompiled = await compile(allSteps);
+const gradCompiled = await compile(gradF);
+
+export const optimize = () => {
+  const { initV, initX } = init(robot);
+  let { weights1, weights2, bias1, bias2 } = init_weights_biases();
+
+  for (let i = 0; i < iter; i++) {
+    let total_norm_sqr = 0;
+    const { loss, bias1Grad, bias2Grad, weights1Grad, weights2Grad } =
+      gradCompiled(initX, initV, weights1, weights2, bias1, bias2);
+    console.log(`Iter=${i} Loss=${loss}`);
+    for (let i = 0; i < n_hidden; i++) {
+      for (let j = 0; j < n_input_states; j++) {
+        total_norm_sqr += weights1Grad[i][j] ** 2;
+      }
+      total_norm_sqr += bias1Grad[i] ** 2;
+    }
+    for (let i = 0; i < n_springs; i++) {
+      for (let j = 0; j < n_hidden; j++) {
+        total_norm_sqr += weights2Grad[i][j] ** 2;
+      }
+      total_norm_sqr += bias2Grad[i] ** 2;
+    }
+
+    const gradient_clip = 0.2;
+    const scale = gradient_clip / (total_norm_sqr ** 0.5 + 1e-6);
+    for (let i = 0; i < n_hidden; i++) {
+      for (let j = 0; j < n_input_states; j++) {
+        weights1[i][j] -= scale * weights1Grad[i][j];
+      }
+      bias1[i] -= scale * bias1Grad[i];
+    }
+    for (let i = 0; i < n_springs; i++) {
+      for (let j = 0; j < n_hidden; j++) {
+        weights2[i][j] -= scale * weights2Grad[i][j];
+      }
+      bias2[i] -= scale * bias2Grad[i];
+    }
+  }
+  return { weights1, weights2, bias1, bias2 };
+};

--- a/mass-spring/src/script.ts
+++ b/mass-spring/src/script.ts
@@ -1,0 +1,17 @@
+import { init, optimize, stepsCompiled } from "./optimizer";
+import { robots } from "./robots";
+
+// setup robot
+const robot = robots[1]();
+const { initV, initX } = init(robot);
+// optimize and record timing info
+const start = performance.now();
+const { weights1, weights2, bias1, bias2 } = optimize();
+const end = performance.now();
+console.log(`Optimization took ${end - start}ms`);
+const {
+  // acts,
+  // xs,
+  loss: newLoss,
+} = stepsCompiled(initX, initV, weights1, weights2, bias1, bias2);
+console.log(`Loss=${newLoss}`);


### PR DESCRIPTION
This PR refactors both `mass-springs` and `billards` to be node-compatible, i.e. decoupling the learning/optimization script from rendering, and provide node scripts via `npm run test`.